### PR TITLE
Accessibility bugs 3874890 and 3863543 fixes.

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,12 +1,12 @@
 <header>
   <h2 class="header">{{ site.title | default: site.github.repository_name }}</h2>
   <nav class="main-nav">
-    <ul>
+    <ul role="tablist">
       {% assign navigation_pages = site.html_pages | sort: 'navigation_weight' %}
       {% for p in navigation_pages %}
       {% if p.navigation_weight %}
       <li{% if p.url == page.url %} class="active"{% endif %}>
-        <a href="{{ site.baseurl }}{{ p.url }}" {% if p.url == page.url %}aria-label= "{{p.title}} active"{% endif %}>
+        <a href="{{ site.baseurl }}{{ p.url }}" {% if p.url == page.url %}aria-label= "{{p.title}} active"{% endif %} role="tab">
           {{ p.title }}
         </a>
       </li>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,8 +8,17 @@ navigation_weight: 2
 
 Let's get this straight: we really strive to help you be as efficient as possible when building Solutions. That was and still remains the primary goal of the *Solution Authoring Workspace* (aka *SAW*).
 
-1. TOC
-{:toc}
+<ol id="markdown-toc">
+  <li><a href="#wait-what-exactly-is-saw" id="markdown-toc-wait-what-exactly-is-saw" aria-label="1. Wait! What exactly is SAW?">Wait! What <em>exactly</em> is <em>SAW</em>?</a></li>
+  <li><a href="#hmm-okay-and-what-are-those-tools" id="markdown-toc-hmm-okay-and-what-are-those-tools" aria-label="2. Hmm… Okay. And what are those tools?">Hmm… Okay. And what are those tools?</a></li>
+  <li><a href="#that-was-easy-now-what" id="markdown-toc-that-was-easy-now-what" aria-label="3. That was easy! Now what?">That was easy! Now what?</a>   
+    <ol>
+      <li><a href="#package-1-in-browser-solution-authoring-environment" id="markdown-toc-package-1-in-browser-solution-authoring-environment" aria-label="3(1). Package 1: In-browser Solution authoring environment">Package 1: In-browser Solution authoring environment</a></li>
+      <li><a href="#package-2-local-solution-development-on-windows" id="markdown-toc-package-2-local-solution-development-on-windows" aria-label="3(2). Package 2: Local Solution development on Windows">Package 2: Local Solution development on Windows</a></li>
+    </ol>
+  </li>
+  <li><a href="#configuration" id="markdown-toc-configuration" aria-label="4. Configuration">Configuration</a></li>
+</ol>
 
 ## Wait! What *exactly* is *SAW*?
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -6,8 +6,42 @@ navigation_weight: 2
 {:.no_toc}
 # Tutorial
 
-1. TOC
-{:toc}
+<ol id="markdown-toc">
+  <li><a href="#learning-objectives" id="markdown-toc-learning-objectives" aria-label="1. Learning objectives">Learning objectives</a></li>
+  <li><a href="#before-we-begin" id="markdown-toc-before-we-begin" aria-label="2. Before we begin">Before we begin</a></li>
+  <li><a href="#the-samples" id="markdown-toc-the-samples" aria-label="3. The Samples">The Samples</a>    <ol>
+      <li><a href="#trying-out-a-sample" id="markdown-toc-trying-out-a-sample" aria-label="3(1). Trying out a sample">Trying out a sample</a></li>
+      <li><a href="#what-happens-during-a-ciqs-deployment" id="markdown-toc-what-happens-during-a-ciqs-deployment" aria-label="3(2). What happens during a CIQS deployment?">What happens during a CIQS deployment?</a>        <ol>
+          <li><a href="#deployment-creation" id="markdown-toc-deployment-creation" aria-label="3(2)(1). Deployment creation">Deployment creation</a></li>
+          <li><a href="#resource-provisioning" id="markdown-toc-resource-provisioning" aria-label="3(2)(2). Resource provisioning">Resource provisioning</a></li>
+          <li><a href="#post-deployment-instructions" id="markdown-toc-post-deployment-instructions" aria-label="3(2)(3). Post-deployment instructions">Post-deployment instructions</a></li>
+        </ol>
+      </li>
+    </ol>
+  </li>
+  <li><a href="#essential-components-of-a-ciqs-solution" id="markdown-toc-essential-components-of-a-ciqs-solution" aria-label="4. Essential components of a CIQS solution">Essential components of a CIQS solution</a></li>
+  <li><a href="#deep-dive" id="markdown-toc-deep-dive" aria-label="5. Deep dive">Deep dive</a>    <ol>
+      <li><a href="#chicken-and-egg-011-chickenandegg" id="markdown-toc-chicken-and-egg-011-chickenandegg" aria-label="5(1). Chicken and egg (011-chickenandegg)">Chicken and egg (011-chickenandegg)</a></li>
+      <li><a href="#solution-dashboard-008-solutiondashboard" id="markdown-toc-solution-dashboard-008-solutiondashboard" aria-label="5(2). Solution dashboard (008-solutiondashboard)">Solution dashboard (008-solutiondashboard)</a></li>
+    </ol>
+  </li>
+  <li><a href="#chicken-and-egg-on-steroids-hands-on-exercise" id="markdown-toc-chicken-and-egg-on-steroids-hands-on-exercise" aria-label="6. Chicken and egg on steroids (hands-on exercise)">Chicken and egg on steroids (hands-on exercise)</a>    <ol>
+      <li><a href="#copy-011-chickenandegg-sample-into-the-solutions-directory" id="markdown-toc-copy-011-chickenandegg-sample-into-the-solutions-directory" aria-label="6(1). Copy 011-chickenandegg sample into the Solutions directory">Copy 011-chickenandegg sample into the Solutions directory</a></li>
+      <li><a href="#update-title-and-description" id="markdown-toc-update-title-and-description" aria-label="6(2). Update <Title> and <Description>">Update <code class="highlighter-rouge">&lt;Title&gt;</code> and <code class="highlighter-rouge">&lt;Description&gt;</code></a></li>
+      <li><a href="#update-the-first-manual-step" id="markdown-toc-update-the-first-manual-step" aria-label="6(3). Update the first <Manual> step">Update the first <code class="highlighter-rouge">&lt;Manual&gt;</code> step</a></li>
+      <li><a href="#remove-the-second-azurefunctionapp-provisioning-step-from-the-manifest" id="markdown-toc-remove-the-second-azurefunctionapp-provisioning-step-from-the-manifest" aria-label="6(4). Remove the second <AzureFunctionApp> provisioning step from the Manifest">Remove the second <code class="highlighter-rouge">&lt;AzureFunctionApp&gt;</code> provisioning step from the <code class="highlighter-rouge">Manifest</code></a></li>
+      <li><a href="#incorporate-and-slightly-tweak-stuff-from-008-solutiondashboard-into-your-new-solution" id="markdown-toc-incorporate-and-slightly-tweak-stuff-from-008-solutiondashboard-into-your-new-solution" aria-label="6(5). Incorporate (and slightly tweak) stuff from 008-solutiondashboard into your new solution">Incorporate (and slightly tweak) stuff from 008-solutiondashboard into your new solution</a></li>
+      <li><a href="#modify-the-hatch-function-to-hatch-eggs-into-the-sql-database" id="markdown-toc-modify-the-hatch-function-to-hatch-eggs-into-the-sql-database" aria-label="6(6). Modify the hatch function to hatch eggs into the SQL database">Modify the <code class="highlighter-rouge">hatch</code> function to hatch eggs into the SQL database</a></li>
+      <li><a href="#final-touches" id="markdown-toc-final-touches" aria-label="6(7). Final touches">Final touches</a></li>
+    </ol>
+  </li>
+  <li><a href="#appendix" id="markdown-toc-appendix" aria-label="7. Appendix">Appendix</a>    <ol>
+      <li><a href="#manifestxml-changes-diff" id="markdown-toc-manifestxml-changes-diff" aria-label="7(1). Manifest.xml changes (diff)">Manifest.xml changes (diff)</a></li>
+      <li><a href="#solutiondatatablecsx" id="markdown-toc-solutiondatatablecsx" aria-label="7(2). SolutionDataTable.csx">SolutionDataTable.csx</a></li>
+      <li><a href="#functionshatchruncsx-changes-diff" id="markdown-toc-functionshatchruncsx-changes-diff" aria-label="7(3). functions/hatch/run.csx changes (diff)">functions/hatch/run.csx changes (diff)</a></li>
+    </ol>
+  </li>
+</ol>
 
 ## Learning objectives
 


### PR DESCRIPTION
Jekyll auto Table of Contents (TOC) does not provide the level of support we need to add aria accessibility compliance. Writing in equivalent html with accessibility on getting-started.md and tutorial.md.